### PR TITLE
Unbounded frame calculation to introduce monotonicity

### DIFF
--- a/abft/calc_frame_test.go
+++ b/abft/calc_frame_test.go
@@ -13,6 +13,7 @@ func TestCalFrameIdx_10000(t *testing.T) {
 	testCalcFrameIdx(t, 10000)
 }
 
+// testCalcFrameIdx verifies that lagging validator calculates correct frame numbers after a (large) pause
 func testCalcFrameIdx(t *testing.T, gap int) {
 	nodes := tdag.GenNodes(2)
 	// Give one validator quorum power to advance the frames on it's own
@@ -33,6 +34,7 @@ func testCalcFrameIdx(t *testing.T, gap int) {
 
 var maxLamport idx.Lamport = 0
 
+// processTestEvent builds and pipes the event through main Lacehsis' DAG manipulation pipeline
 func processTestEvent(t *testing.T, lch *TestLachesis, store *EventStore, validatorId idx.ValidatorID, seq idx.Event, parents hash.Events) *tdag.TestEvent {
 	event := &tdag.TestEvent{}
 	event.SetSeq(seq)
@@ -44,6 +46,7 @@ func processTestEvent(t *testing.T, lch *TestLachesis, store *EventStore, valida
 	if err := lch.Build(event); err != nil {
 		t.Errorf("error while building event for validator: %d, seq: %d, err: %v", validatorId, seq, err)
 	}
+	// default sample hash assigned through Build is enough
 	store.SetEvent(event)
 	if err := lch.Process(event); err != nil {
 		t.Errorf("error while processing event for validator: %d, seq: %d, err: %v", validatorId, seq, err)

--- a/abft/calc_frame_test.go
+++ b/abft/calc_frame_test.go
@@ -1,0 +1,52 @@
+package abft
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+)
+
+func TestCalFrameIdx_10000(t *testing.T) {
+	testCalcFrameIdx(t, 10000)
+}
+
+func testCalcFrameIdx(t *testing.T, gap int) {
+	nodes := tdag.GenNodes(2)
+	// Give one validator quorum power to advance the frames on it's own
+	lch, _, store, _ := FakeLachesis(nodes, []pos.Weight{1, 3})
+
+	laggyGenesis := processTestEvent(t, lch, store, nodes[0], 1, hash.Events{})
+	parentEvent := processTestEvent(t, lch, store, nodes[1], 1, hash.Events{})
+	for i := 0; i < gap; i++ {
+		parentEvent = processTestEvent(t, lch, store, nodes[1], idx.Event(parentEvent.Seq()+1), hash.Events{parentEvent.ID()})
+	}
+	// Lagging validator creates an event after a frame gap
+	finalEvent := processTestEvent(t, lch, store, nodes[0], laggyGenesis.Seq()+1, hash.Events{laggyGenesis.ID(), parentEvent.ID()})
+
+	if want, got := laggyGenesis.Frame()+idx.Frame(gap)+1, finalEvent.Frame(); want != got {
+		t.Errorf("expected calculated frame number of lagging validator to be: %d, got: %d", gap, finalEvent.Frame())
+	}
+}
+
+var maxLamport idx.Lamport = 0
+
+func processTestEvent(t *testing.T, lch *TestLachesis, store *EventStore, validatorId idx.ValidatorID, seq idx.Event, parents hash.Events) *tdag.TestEvent {
+	event := &tdag.TestEvent{}
+	event.SetSeq(seq)
+	event.SetCreator(validatorId)
+	event.SetParents(parents)
+	maxLamport = maxLamport + 1
+	event.SetLamport(maxLamport)
+	event.SetEpoch(lch.store.GetEpoch())
+	if err := lch.Build(event); err != nil {
+		t.Errorf("error while building event for validator: %d, seq: %d, err: %v", validatorId, seq, err)
+	}
+	store.SetEvent(event)
+	if err := lch.Process(event); err != nil {
+		t.Errorf("error while processing event for validator: %d, seq: %d, err: %v", validatorId, seq, err)
+	}
+	return event
+}

--- a/abft/config.go
+++ b/abft/config.go
@@ -3,6 +3,7 @@ package abft
 import "github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 
 type Config struct {
+	// Suppresses the frame missmatch panic - used only for importing older historical event files, disabled by default
 	SuppressFramePanic bool
 }
 

--- a/abft/config.go
+++ b/abft/config.go
@@ -3,16 +3,21 @@ package abft
 import "github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 
 type Config struct {
+	SuppressFramePanic bool
 }
 
 // DefaultConfig for livenet.
 func DefaultConfig() Config {
-	return Config{}
+	return Config{
+		SuppressFramePanic: false,
+	}
 }
 
 // LiteConfig is for tests or inmemory.
 func LiteConfig() Config {
-	return Config{}
+	return Config{
+		SuppressFramePanic: false,
+	}
 }
 
 // StoreCacheConfig is a cache config for store db.

--- a/abft/event_processing.go
+++ b/abft/event_processing.go
@@ -23,7 +23,7 @@ func (p *Orderer) Build(e dag.MutableEvent) error {
 		p.crit(errors.New("event wasn't created by an existing validator"))
 	}
 
-	_, frame := p.calcFrameIdx(e, false)
+	_, frame := p.calcFrameIdx(e)
 	e.SetFrame(frame)
 
 	return nil
@@ -51,7 +51,7 @@ func (p *Orderer) Process(e dag.Event) (err error) {
 // checkAndSaveEvent checks consensus-related fields: Frame, IsRoot
 func (p *Orderer) checkAndSaveEvent(e dag.Event) (error, idx.Frame) {
 	// check frame & isRoot
-	selfParentFrame, frameIdx := p.calcFrameIdx(e, true)
+	selfParentFrame, frameIdx := p.calcFrameIdx(e)
 	if e.Frame() != frameIdx {
 		return ErrWrongFrame, 0
 	}
@@ -160,30 +160,17 @@ func (p *Orderer) forklessCausedByQuorumOn(e dag.Event, f idx.Frame) bool {
 	return observedCounter.HasQuorum()
 }
 
-// calcFrameIdx checks root-conditions for new event
-// and returns event's frame.
+// calcFrameIdx checks root-conditions for new event and returns event's frame.
 // It is not safe for concurrent use.
-func (p *Orderer) calcFrameIdx(e dag.Event, checkOnly bool) (selfParentFrame, frame idx.Frame) {
-	selfParentFrame = idx.Frame(0)
-	if e.SelfParent() != nil {
-		selfParentFrame = p.input.GetEvent(*e.SelfParent()).Frame()
+func (p *Orderer) calcFrameIdx(e dag.Event) (selfParentFrame, frame idx.Frame) {
+	if e.SelfParent() == nil {
+		return 0, 1
 	}
-
-	// Note: we cannot "skip" frames and also we must check that event is caused by 2/3W+1 roots at F, even if one
-	// of the parents has a frame >= F+1
-	// The reason of those checks is that "forkless caused" relation isn't transitive in a case if there's at least one
-	// cheater
-
-	maxFrameToCheck := selfParentFrame + 100
-	if checkOnly {
-		maxFrameToCheck = e.Frame()
+	selfParentFrame = p.input.GetEvent(*e.SelfParent()).Frame()
+	frame = selfParentFrame
+	// Find highest frame s.t. event e is forklessCausedByQuorumOn by frame-1 roots
+	for p.forklessCausedByQuorumOn(e, frame) {
+		frame++
 	}
-
-	var f idx.Frame
-	for f = selfParentFrame; f < maxFrameToCheck && p.forklessCausedByQuorumOn(e, f); f++ {
-	}
-	if f == 0 {
-		f = 1
-	}
-	return selfParentFrame, f
+	return selfParentFrame, frame
 }

--- a/abft/event_processing.go
+++ b/abft/event_processing.go
@@ -52,7 +52,7 @@ func (p *Orderer) Process(e dag.Event) (err error) {
 func (p *Orderer) checkAndSaveEvent(e dag.Event) (error, idx.Frame) {
 	// check frame & isRoot
 	selfParentFrame, frameIdx := p.calcFrameIdx(e)
-	if e.Frame() != frameIdx {
+	if !p.config.SuppressFramePanic && e.Frame() != frameIdx {
 		return ErrWrongFrame, 0
 	}
 


### PR DESCRIPTION
This PR reformats the frame calculation function to let iterative frame calculation run unbounded, instead of being limited by 100 frames 'above' the parent. This is one of the steps required for enforcing frame monotonicity in every event chain. Other steps and codependent changes are present and described in https://github.com/Fantom-foundation/Sonic/pull/227.