### PR TITLE
Batch interface: Add delete range function

### DIFF
--- a/kvdb/devnulldb/devnulldb.go
+++ b/kvdb/devnulldb/devnulldb.go
@@ -119,6 +119,11 @@ func (b *batch) Replay(w kvdb.Writer) error {
 	return nil
 }
 
+// DeleteRange deletes a range of the batch.
+func (b *batch) DeleteRange(start, end []byte) error {
+	return nil
+}
+
 // iterator can walk over the (potentially partial) keyspace of a memory key
 // value store. Internally it is a deep copy of the entire iterated state,
 // sorted by keys.

--- a/kvdb/flushable/flushable.go
+++ b/kvdb/flushable/flushable.go
@@ -556,6 +556,20 @@ func (b *cacheBatch) Replay(w kvdb.Writer) error {
 	return nil
 }
 
+// DeleteRange deletes a range of the batch.
+func (b *cacheBatch) DeleteRange(start, end []byte) error {
+	// delete all keys in range
+	for it := b.db.modified.Iterator(); it.Next(); {
+		key := []byte(it.Key().(string))
+		if bytes.Compare(key, start) < 0 || bytes.Compare(key, end) >= 0 {
+			continue // skip keys that are not in the range
+		}
+		b.writes = append(b.writes, kv{common.CopyBytes(key), nil})
+		b.size += len(key)
+	}
+	return nil
+}
+
 // Snapshot is a DB snapshot.
 type Snapshot struct {
 	flushableReader

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -34,8 +34,8 @@ type Batch interface {
 	// Replay replays the batch contents.
 	Replay(w Writer) error
 
-	// DeleteRange deletes a range of the batch.
-	DeleteRange([]byte, []byte) error
+	// DeleteRange deletes the range [start, end) from batch.
+	DeleteRange(start []byte, end []byte) error
 }
 
 // Iterator iterates over a database's key/value pairs in ascending key order.

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -33,6 +33,9 @@ type Batch interface {
 
 	// Replay replays the batch contents.
 	Replay(w Writer) error
+
+	// DeleteRange deletes a range of the batch.
+	DeleteRange([]byte, []byte) error
 }
 
 // Iterator iterates over a database's key/value pairs in ascending key order.

--- a/kvdb/leveldb/leveldb.go
+++ b/kvdb/leveldb/leveldb.go
@@ -5,7 +5,6 @@
 package leveldb
 
 import (
-	"bytes"
 	"fmt"
 	"sync"
 
@@ -325,11 +324,8 @@ func (b *batch) Replay(w kvdb.Writer) error {
 }
 
 func (b *batch) DeleteRange(start, end []byte) error {
-	for it := b.db.NewIterator(util.BytesPrefix(nil), nil); it.Next(); {
+	for it := b.db.NewIterator(&util.Range{Start: start, Limit: end}, nil); it.Next(); {
 		key := it.Key()
-		if bytes.Compare(key, start) < 0 || bytes.Compare(key, end) >= 0 {
-			continue // skip keys that are not in the range
-		}
 		b.b.Delete(key)
 		b.size++
 	}

--- a/kvdb/leveldb/leveldb_test.go
+++ b/kvdb/leveldb/leveldb_test.go
@@ -1,15 +1,13 @@
 package leveldb
 
 import (
-	"os"
 	"testing"
 
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
 func TestBatchDeleteRange_KeysInRangeGetDeleted(t *testing.T) {
-	db, cleanup := newTestDB(t)
-	defer cleanup()
+	db := newTestDB(t)
 
 	// Insert test keys: "a", "b", "c", "d", "e"
 	keys := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e")}
@@ -58,8 +56,7 @@ func TestBatchDeleteRange_KeysInRangeGetDeleted(t *testing.T) {
 }
 
 func TestBatchDeleteRange_NoKeysInRange(t *testing.T) {
-	db, cleanup := newTestDB(t)
-	defer cleanup()
+	db := newTestDB(t)
 
 	// Insert keys "a", "b"
 	keys := [][]byte{[]byte("a"), []byte("b")}
@@ -94,14 +91,16 @@ func TestBatchDeleteRange_NoKeysInRange(t *testing.T) {
 	}
 }
 
-func newTestDB(t *testing.T) (*leveldb.DB, func()) {
+func newTestDB(t *testing.T) *leveldb.DB {
 	dir := t.TempDir()
 	db, err := leveldb.OpenFile(dir, nil)
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
-	return db, func() {
-		db.Close()
-		os.RemoveAll(dir)
-	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close test db: %v", err)
+		}
+	})
+	return db
 }

--- a/kvdb/leveldb/leveldb_test.go
+++ b/kvdb/leveldb/leveldb_test.go
@@ -1,0 +1,107 @@
+package leveldb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func TestBatchDeleteRange_KeysInRangeGetDeleted(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	defer cleanup()
+
+	// Insert test keys: "a", "b", "c", "d", "e"
+	keys := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e")}
+	for _, key := range keys {
+		if err := db.Put(key, []byte("val-"+string(key)), nil); err != nil {
+			t.Fatalf("failed to put key %s: %v", key, err)
+		}
+	}
+
+	batch := &batch{
+		db: db,
+		b:  new(leveldb.Batch),
+	}
+
+	// Delete keys in range ["b", "d")
+	err := batch.DeleteRange([]byte("b"), []byte("d"))
+	if err != nil {
+		t.Fatalf("DeleteRange failed: %v", err)
+	}
+
+	// Write the batch
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch write failed: %v", err)
+	}
+
+	// Check which keys remain
+	tests := []struct {
+		key      []byte
+		expected bool
+	}{
+		{[]byte("a"), true},
+		{[]byte("b"), false},
+		{[]byte("c"), false},
+		{[]byte("d"), true},
+		{[]byte("e"), true},
+	}
+	for _, test := range tests {
+		ok, err := db.Has(test.key, nil)
+		if err != nil {
+			t.Fatalf("db.Has(%s) failed: %v", test.key, err)
+		}
+		if ok != test.expected {
+			t.Errorf("key %s: expected %v, got %v", test.key, test.expected, ok)
+		}
+	}
+}
+
+func TestBatchDeleteRange_NoKeysInRange(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	defer cleanup()
+
+	// Insert keys "a", "b"
+	keys := [][]byte{[]byte("a"), []byte("b")}
+	for _, key := range keys {
+		if err := db.Put(key, []byte("val"), nil); err != nil {
+			t.Fatalf("failed to put key: %v", err)
+		}
+	}
+
+	batch := &batch{
+		db: db,
+		b:  new(leveldb.Batch),
+	}
+
+	// Delete range ["c", "d") -- no keys in this range
+	err := batch.DeleteRange([]byte("c"), []byte("d"))
+	if err != nil {
+		t.Fatalf("DeleteRange failed: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch write failed: %v", err)
+	}
+
+	for _, key := range keys {
+		ok, err := db.Has(key, nil)
+		if err != nil {
+			t.Fatalf("db.Has failed: %v", err)
+		}
+		if !ok {
+			t.Errorf("key %s should not be deleted", key)
+		}
+	}
+}
+
+func newTestDB(t *testing.T) (*leveldb.DB, func()) {
+	dir := t.TempDir()
+	db, err := leveldb.OpenFile(dir, nil)
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	return db, func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+}

--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -489,8 +489,11 @@ func (b *batch) Replay(w kvdb.Writer) (err error) {
 func (b *batch) DeleteRange(start, end []byte) error {
 	for iter := b.b.Reader(); len(iter) > 0; {
 		_, key, _, ok, err := iter.Next()
-		if err != nil && !ok {
+		if err != nil {
 			return err
+		}
+		if !ok {
+			break
 		}
 		if bytes.Compare(key, start) < 0 || bytes.Compare(key, end) >= 0 {
 			continue // skip keys that are not in the range

--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -1,6 +1,7 @@
 package pebble
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 
@@ -483,4 +484,18 @@ func (b *batch) Replay(w kvdb.Writer) (err error) {
 		}
 	}
 	return
+}
+
+func (b *batch) DeleteRange(start, end []byte) error {
+	for iter := b.b.Reader(); len(iter) > 0; {
+		_, key, _, ok, err := iter.Next()
+		if err != nil && !ok {
+			return err
+		}
+		if bytes.Compare(key, start) < 0 || bytes.Compare(key, end) >= 0 {
+			continue // skip keys that are not in the range
+		}
+		b.size++
+	}
+	return b.b.DeleteRange(start, end, pebble.NoSync)
 }

--- a/kvdb/pebble/pebble_test.go
+++ b/kvdb/pebble/pebble_test.go
@@ -1,0 +1,111 @@
+package pebble
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchDeleteRange_KeysInRangeGetDeleted(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	defer cleanup()
+
+	// Insert some keys
+	keys := [][]byte{
+		[]byte("a"),
+		[]byte("b"),
+		[]byte("c"),
+		[]byte("d"),
+		[]byte("e"),
+	}
+	for _, k := range keys {
+		db.Set(k, []byte("value-"+string(k)), nil)
+	}
+
+	batch := batch{
+		db:   db,
+		b:    db.NewBatch(),
+		size: 0,
+	}
+	// Delete keys in range ["b", "d")
+	err := batch.DeleteRange([]byte("b"), []byte("d"))
+	require.NoError(t, err)
+
+	// Write the batch
+	err = batch.Write()
+	require.NoError(t, err)
+
+	// Check which keys remain
+	testKeys := [][]byte{
+		[]byte("a"),
+		[]byte("d"),
+		[]byte("e"),
+	}
+
+	got := [][]byte{}
+	for _, key := range testKeys {
+		_, _, err := db.Get(key)
+		if err == nil {
+			got = append(got, key)
+		}
+	}
+	require.ElementsMatch(t, got, testKeys, "Keys not deleted in range")
+}
+
+func TestBatchDeleteRange_NoKeysInRange(t *testing.T) {
+	db, cleanup := newTestDB(t)
+	defer cleanup()
+
+	// Insert some keys
+	keys := [][]byte{
+		[]byte("a"),
+		[]byte("b"),
+		[]byte("c"),
+	}
+	for _, k := range keys {
+		db.Set(k, []byte("value-"+string(k)), nil)
+	}
+
+	batch := batch{
+		db:   db,
+		b:    db.NewBatch(),
+		size: 0,
+	}
+	// Delete keys in range ["d", "e")
+	err := batch.DeleteRange([]byte("d"), []byte("e"))
+	require.NoError(t, err)
+
+	// Write the batch
+	err = batch.Write()
+	require.NoError(t, err)
+
+	// Check which keys remain
+	testKeys := [][]byte{
+		[]byte("a"),
+		[]byte("b"),
+		[]byte("c"),
+	}
+
+	got := [][]byte{}
+	for _, key := range testKeys {
+		_, _, err := db.Get(key)
+		if err == nil {
+			got = append(got, key)
+		}
+	}
+	require.ElementsMatch(t, got, testKeys, "Keys not deleted in range")
+}
+
+func newTestDB(t *testing.T) (*pebble.DB, func()) {
+	dir := t.TempDir()
+	db, err := pebble.Open(dir+"testDB", &pebble.Options{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	return db, func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+}

--- a/kvdb/synced/store.go
+++ b/kvdb/synced/store.go
@@ -125,3 +125,11 @@ func (b *syncedBatch) Replay(w kvdb.Writer) error {
 
 	return b.underlying.Replay(w)
 }
+
+// DeleteRange deletes a range of the batch.
+func (b *syncedBatch) DeleteRange(start, end []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.underlying.DeleteRange(start, end)
+}

--- a/kvdb/table/table.go
+++ b/kvdb/table/table.go
@@ -130,6 +130,10 @@ func (b *batch) Replay(w kvdb.Writer) error {
 	return b.batch.Replay(&replayer{w, b.prefix})
 }
 
+func (b *batch) DeleteRange(start, end []byte) error {
+	return b.batch.DeleteRange(prefixed(start, b.prefix), prefixed(end, b.prefix))
+}
+
 /*
  * Replayer
  */


### PR DESCRIPTION
[Geth added](https://github.com/ethereum/go-ethereum/pull/31947) a `deleteRange` function to their `batch` interface. This PR adds the `deleteRange` function in order to stay compatible with geth and continue to use their interface in the [sonic kvdb2ethdb adapter](https://github.com/0xsoniclabs/sonic/blob/main/utils/adapters/kvdb2ethdb/adapter.go).