### PR TITLE
Fix announcements duplication in itemsfetcher

### DIFF
--- a/gossip/itemsfetcher/fetcher.go
+++ b/gossip/itemsfetcher/fetcher.go
@@ -20,7 +20,7 @@ var (
 	errTerminated = errors.New("terminated")
 )
 
-// ItemsRequesterFn is a callback type for sending a item retrieval request.
+// ItemsRequesterFn is a callback type for sending an item retrieval request.
 type ItemsRequesterFn func([]interface{}) error
 
 type announceData struct {
@@ -67,7 +67,7 @@ type Callback struct {
 	Suspend        func() bool
 }
 
-// New creates a item fetcher to retrieve items based on hash announcements.
+// New creates an item fetcher to retrieve items based on hash announcements.
 func New(cfg Config, callback Callback) *Fetcher {
 	f := &Fetcher{
 		cfg:           cfg,
@@ -102,7 +102,7 @@ func (f *Fetcher) Stop() {
 	f.wg.Wait()
 }
 
-// Overloaded returns true if too much items are being requested
+// Overloaded returns true if too many items are being requested.
 func (f *Fetcher) Overloaded() bool {
 	return len(f.receivedItems) > f.cfg.MaxQueuedBatches*3/4 ||
 		len(f.notifications) > f.cfg.MaxQueuedBatches*3/4 ||
@@ -176,9 +176,8 @@ func (f *Fetcher) processNotification(notification announcesBatch, fetchTimer *t
 	now := time.Now()
 	for _, id := range notification.ids {
 		// add new announcement. other peers may already have announced it, so it's an array
-		anns := f.getAnnounces(id)
-		anns = append(anns, notification.announceData)
-		f.announces.Add(id, append(anns, notification.announceData), uint(len(anns)))
+		anns := append(f.getAnnounces(id), notification.announceData)
+		f.announces.Add(id, anns, uint(len(anns)))
 		// if it wasn't announced before, then schedule for fetching this time
 		if !noFetching {
 			if _, ok := f.fetching[id]; !ok {

--- a/gossip/itemsfetcher/fetcher_test.go
+++ b/gossip/itemsfetcher/fetcher_test.go
@@ -1,0 +1,56 @@
+package itemsfetcher_test
+
+import (
+	"github.com/Fantom-foundation/lachesis-base/gossip/itemsfetcher"
+	"testing"
+	"time"
+)
+
+func TestFetcher(t *testing.T) {
+
+	fetcher := itemsfetcher.New(itemsfetcher.Config{
+		ForgetTimeout:       1 * time.Minute,
+		ArriveTimeout:       1000 * time.Millisecond,
+		GatherSlack:         100 * time.Millisecond,
+		HashLimit:           10000,
+		MaxBatch:            2,
+		MaxParallelRequests: 1,
+		MaxQueuedBatches:    2,
+	}, itemsfetcher.Callback{
+		OnlyInterested: func(ids []interface{}) []interface{} {
+			return ids // we are interested in any announced item
+		},
+		Suspend: func() bool {
+			return false
+		},
+	})
+	fetcher.Start()
+	defer fetcher.Stop()
+
+	announcedIds1 := []interface{}{"eventA", "eventB", "eventC"}
+	announcedIds2 := []interface{}{"eventD", "eventE"}
+	fetchedIds := make([]interface{}, 0, 5)
+
+	fetchItemsFn := func(ids []interface{}) error {
+		fetchedIds = append(fetchedIds, ids...)
+		return nil
+	}
+
+	err := fetcher.NotifyAnnounces("peer1", announcedIds1, time.Now(), fetchItemsFn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Millisecond)
+	if len(fetchedIds) != 3 {
+		t.Errorf("unexpected fetchedIds: %v", fetchedIds)
+	}
+
+	err = fetcher.NotifyAnnounces("peer1", announcedIds2, time.Now(), fetchItemsFn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Millisecond)
+	if len(fetchedIds) != 5 {
+		t.Errorf("unexpected fetchedIds: %v", fetchedIds)
+	}
+}

--- a/gossip/itemsfetcher/fetcher_test.go
+++ b/gossip/itemsfetcher/fetcher_test.go
@@ -18,7 +18,7 @@ func TestFetcher(t *testing.T) {
 		MaxQueuedBatches:    2,
 	}, itemsfetcher.Callback{
 		OnlyInterested: func(ids []interface{}) []interface{} {
-			return ids // we are interested in any announced item
+			return ids // we are interested in all announced item
 		},
 		Suspend: func() bool {
 			return false


### PR DESCRIPTION
When `itemsfetcher` obtains a notification about a new available event, it appends the peer into the list of peers who knows the event. However because of a code duplication, it is appended twice:

```
		anns := f.getAnnounces(id)
		anns = append(anns, notification.announceData)
		f.announces.Add(id, append(anns, notification.announceData), ...)
```

This should not be affecting the resulting client behavior, however the fix should help to clean the code.

Suggestions for the unittest improvements (to avoid the sleep) are welcome. (However my intention was to minimize production code changes.)