### PR TITLE
Batch add close function

### DIFF
--- a/kvdb/devnulldb/devnulldb.go
+++ b/kvdb/devnulldb/devnulldb.go
@@ -124,6 +124,10 @@ func (b *batch) DeleteRange(start, end []byte) error {
 	return nil
 }
 
+// Close closes the batch and releases all associated resources.
+func (b *batch) Close() {
+}
+
 // iterator can walk over the (potentially partial) keyspace of a memory key
 // value store. Internally it is a deep copy of the entire iterated state,
 // sorted by keys.

--- a/kvdb/flushable/flushable.go
+++ b/kvdb/flushable/flushable.go
@@ -570,6 +570,10 @@ func (b *cacheBatch) DeleteRange(start, end []byte) error {
 	return nil
 }
 
+// Close closes the batch and releases all associated resources.
+func (b *cacheBatch) Close() {
+}
+
 // Snapshot is a DB snapshot.
 type Snapshot struct {
 	flushableReader

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -36,6 +36,9 @@ type Batch interface {
 
 	// DeleteRange deletes the range [start, end) from batch.
 	DeleteRange(start []byte, end []byte) error
+
+	// Close closes the batch and releases all associated resources.
+	Close()
 }
 
 // Iterator iterates over a database's key/value pairs in ascending key order.

--- a/kvdb/leveldb/leveldb.go
+++ b/kvdb/leveldb/leveldb.go
@@ -332,6 +332,10 @@ func (b *batch) DeleteRange(start, end []byte) error {
 	return nil
 }
 
+// Close closes the batch and releases all associated resources.
+func (b *batch) Close() {
+}
+
 // replayer is a small wrapper to implement the correct replay methods.
 type replayer struct {
 	writer  kvdb.Writer

--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -502,3 +502,7 @@ func (b *batch) DeleteRange(start, end []byte) error {
 	}
 	return b.b.DeleteRange(start, end, pebble.NoSync)
 }
+
+// Close closes the batch and releases all associated resources.
+func (b *batch) Close() {
+}

--- a/kvdb/synced/store.go
+++ b/kvdb/synced/store.go
@@ -133,3 +133,11 @@ func (b *syncedBatch) DeleteRange(start, end []byte) error {
 
 	return b.underlying.DeleteRange(start, end)
 }
+
+// Close closes the batch and releases all associated resources.
+func (b *syncedBatch) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.underlying.Close()
+}

--- a/kvdb/table/table.go
+++ b/kvdb/table/table.go
@@ -134,6 +134,9 @@ func (b *batch) DeleteRange(start, end []byte) error {
 	return b.batch.DeleteRange(prefixed(start, b.prefix), prefixed(end, b.prefix))
 }
 
+func (b *batch) Close() {
+}
+
 /*
  * Replayer
  */


### PR DESCRIPTION
Geth version 1.17.2 added a new function to the `Batch` interface. A simple close method is added, which also needs to be updated in lachesis base.